### PR TITLE
Remove INSTALL_NAME_DIR definition

### DIFF
--- a/cmake/pods.cmake
+++ b/cmake/pods.cmake
@@ -368,11 +368,7 @@ macro(pods_config_search_paths)
         else(${CMAKE_INSTALL_RPATH})
             set(CMAKE_INSTALL_RPATH ${LIBRARY_INSTALL_PATH})
         endif(${CMAKE_INSTALL_RPATH})
-
-        # for osx, which uses "install name" path rather than rpath
-        #set(CMAKE_INSTALL_NAME_DIR ${LIBRARY_OUTPUT_PATH})
-        set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_RPATH})
-        
+      
         # hack to force cmake always create install and clean targets 
         install(FILES DESTINATION)
         string(RANDOM LENGTH 32 __rand_target__name__)


### PR DESCRIPTION
Defining INSTALL_NAME_DIR CMake variable forces the install name to be an
absolute path instead of `@rpath/{target_name}` [1]. This causes problems
when one tries to relocate the target once it is installed.
This patch removes this target property. If a project needs to keep
the absolute path, INSTALL_NAME_DIR can be set during project configuration.

[1] https://gitlab.kitware.com/cmake/cmake/issues/16589